### PR TITLE
Improve compatibility with TYPO3 13

### DIFF
--- a/Classes/EventListener/FormControllerCreateActionBeforeRenderViewEventListener.php
+++ b/Classes/EventListener/FormControllerCreateActionBeforeRenderViewEventListener.php
@@ -16,6 +16,12 @@ class FormControllerCreateActionBeforeRenderViewEventListener
         }
     }
 
+    public function onConfirmationAction(\In2code\Powermail\Events\FormControllerConfirmationActionEvent $event) {
+        $mail = $event->getMail();
+        if (!$mail->getForm()->isTxCspowermailgdprHidden() && !$mail->isTxCspowermailgdprAccepted()) {
+            $mail->setTxCspowermailgdprAccepted(self::checkParam());
+        }
+    }
     public static function checkParam(): int
     {
         $params = $GLOBALS['TYPO3_REQUEST']->getParsedBody()['tx_powermail_pi1'] ?? $GLOBALS['TYPO3_REQUEST']->getQueryParams()['tx_powermail_pi1'] ?? null;

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -12,3 +12,7 @@ services:
       - name: event.listener
         identifier: 'csPowermailGdprFormControllerCreateActionBeforeRenderViewEventListener'
         event: In2code\Powermail\Events\FormControllerCreateActionBeforeRenderViewEvent
+      - name: event.listener
+        identifier: 'csPowermailGdprFormControllerConfirmationActionEventListener'
+        event: In2code\Powermail\Events\FormControllerConfirmationActionEvent
+        method: 'onConfirmationAction'

--- a/Resources/Private/Templates/Form/Confirmation.html
+++ b/Resources/Private/Templates/Form/Confirmation.html
@@ -73,6 +73,6 @@ Show Confirmation Page
 		</f:if>
 	</f:for>
 
-	<f:form.hidden property="tx_cspowermailgdpr_accepted." value="{mail.txCspowermailgdprAccepted}"/>
+	<f:form.hidden property="tx_cspowermailgdpr_accepted" value="{mail.txCspowermailgdprAccepted ? 1 : 0}"/>
 	<f:form.hidden name="mail[form]" value="{mail.form.uid}" class="powermail_form_uid" />
 </f:section>


### PR DESCRIPTION
The submitted value is currently not carried over the confirmation page and needs a different eventlistener. Otherwise the confirmation page will be rejected when trying to submit the form.

Additionally the value of the hidden tag is set to 0 or 1, since true values are set to the property name when the tag is rendered.